### PR TITLE
Fixed README.md markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https
 sudo apt-get update 
 sudo apt-get install -y dotnet-sdk-5.0
+```
 
 Also, for the "Reports" charts feature:
 


### PR DESCRIPTION
Due to a misplaced "```", half of the file was badly formatted (code was in normal text, normal text was in code blocks)